### PR TITLE
Use most recently used browser when available

### DIFF
--- a/DefaultBrowser/AppDelegate.swift
+++ b/DefaultBrowser/AppDelegate.swift
@@ -253,7 +253,7 @@ class AppDelegate: NSObject {
             if browser.bundleIdentifier == Bundle.main.bundleIdentifier {
                 return false
             }
-            return blocklist.contains(bundleId)
+            return !blocklist.contains(bundleId)
         }).first?.bundleIdentifier {
             return firstRunningBrowser
         }


### PR DESCRIPTION
Fixes #27 

Based on the [refactor](https://github.com/apexskier/DefaultBrowser/commit/5dce737ea941a6b39d51bd9b43e5fe63ae871df8#diff-457711d64b429aa943c45a87e9aa0b69e4516d3db1846b1971904af34130d335L384), it looks like we should filter out browsers in the block list, not filter out browsers not in the blocklist.