### PR TITLE
Update deprecated APIs

### DIFF
--- a/DefaultBrowser.xcodeproj/project.pbxproj
+++ b/DefaultBrowser.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C57375C52DCBC4B20010D944 /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = C5AEAF5D29292C0A00F57C2F /* test.html */; };
 		C58951F41BEAD8BA0093EE2E /* SystemUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58951F31BEAD8BA0093EE2E /* SystemUtilities.swift */; };
 		C5A333771BDAF6EA000767B2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A333761BDAF6EA000767B2 /* AppDelegate.swift */; };
 		C5A333791BDAF6EA000767B2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C5A333781BDAF6EA000767B2 /* Assets.xcassets */; };
@@ -166,6 +167,7 @@
 			files = (
 				C5A333791BDAF6EA000767B2 /* Assets.xcassets in Resources */,
 				C5A3337C1BDAF6EA000767B2 /* MainMenu.xib in Resources */,
+				C57375C52DCBC4B20010D944 /* test.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -318,7 +320,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Default Browser.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 6D9DLTQJSN;
@@ -344,7 +346,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Default Browser.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 6D9DLTQJSN;

--- a/DefaultBrowser.xcodeproj/project.pbxproj
+++ b/DefaultBrowser.xcodeproj/project.pbxproj
@@ -328,7 +328,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.camlittle.DefaultBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -353,7 +353,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.camlittle.DefaultBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/DefaultBrowser.xcodeproj/project.pbxproj
+++ b/DefaultBrowser.xcodeproj/project.pbxproj
@@ -330,7 +330,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.camlittle.DefaultBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -356,7 +356,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.camlittle.DefaultBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";

--- a/DefaultBrowser.xcodeproj/project.pbxproj
+++ b/DefaultBrowser.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 				DEVELOPMENT_TEAM = 6D9DLTQJSN;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = DefaultBrowser/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -349,6 +350,7 @@
 				DEVELOPMENT_TEAM = 6D9DLTQJSN;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = DefaultBrowser/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/DefaultBrowser/AppDelegate.swift
+++ b/DefaultBrowser/AppDelegate.swift
@@ -21,9 +21,9 @@ enum MenuItemTag: Int {
 // Height of each menu item's icon
 let MENU_ITEM_HEIGHT: CGFloat = 16
 
-let supportedSchemes = [
-    "http",
-    "https",
+let browserQualifyingSchemes = ["https", "http"]
+
+let supportedSchemes = browserQualifyingSchemes + [
     "file",
     "html",
 ]
@@ -278,11 +278,12 @@ class AppDelegate: NSObject {
     
     // check if DefaultBrowser is the OS level link handler
     func isCurrentlyDefault() -> Bool {
-        let selfBundleID = Bundle.main.bundleIdentifier!
-        
         var currentlyDefault = true
-        // TODO: LSCopyDefaultHandlerForURLScheme is deprecated but I don't know a replacement
-        if let currentDefaultBrowser = LSCopyDefaultHandlerForURLScheme(supportedSchemes[0] as CFString)?.takeRetainedValue() as String? {
+
+        if let selfBundleID = Bundle.main.bundleIdentifier,
+           let testUrl = URL(string: "\(browserQualifyingSchemes[0])://"),
+           let defaultApplicationUrl = workspace.urlForApplication(toOpen: testUrl),
+           let currentDefaultBrowser = Bundle(url: defaultApplicationUrl)?.bundleIdentifier {
             if currentDefaultBrowser.lowercased() != selfBundleID.lowercased() {
                 currentlyDefault = false
                 defaults.primaryBrowser = currentDefaultBrowser

--- a/DefaultBrowser/AppDelegate.swift
+++ b/DefaultBrowser/AppDelegate.swift
@@ -10,6 +10,7 @@ import Cocoa
 import CoreServices
 import Intents
 import ServiceManagement
+import UniformTypeIdentifiers
 
 // Menu item tags used to fetch them without a direct reference
 enum MenuItemTag: Int {
@@ -22,11 +23,6 @@ enum MenuItemTag: Int {
 let MENU_ITEM_HEIGHT: CGFloat = 16
 
 let browserQualifyingSchemes = ["https", "http"]
-
-let supportedSchemes = browserQualifyingSchemes + [
-    "file",
-    "html",
-]
 
 // Adds a bundle id field to menu items and the browser's icon
 // used in menu bar and preferences primary browser picker
@@ -277,36 +273,96 @@ class AppDelegate: NSObject {
     }
     
     // check if DefaultBrowser is the OS level link handler
-    func isCurrentlyDefault() -> Bool {
-        var currentlyDefault = true
-
-        if let selfBundleID = Bundle.main.bundleIdentifier,
-           let testUrl = URL(string: "\(browserQualifyingSchemes[0])://"),
-           let defaultApplicationUrl = workspace.urlForApplication(toOpen: testUrl),
-           let currentDefaultBrowser = Bundle(url: defaultApplicationUrl)?.bundleIdentifier {
-            if currentDefaultBrowser.lowercased() != selfBundleID.lowercased() {
-                currentlyDefault = false
-                defaults.primaryBrowser = currentDefaultBrowser
-                defaults.browserBlocklist = defaults.browserBlocklist.filter { $0 == currentDefaultBrowser }
-            }
+    func isCurrentlyDefaultHttpHandler() -> Bool? {
+        guard let selfBundleID = Bundle.main.bundleIdentifier,
+              let testUrl = URL(string: "http:"),
+              let defaultApplicationUrl = workspace.urlForApplication(toOpen: testUrl),
+              let currentDefaultBrowser = Bundle(url: defaultApplicationUrl)?.bundleIdentifier else {
+            return nil
         }
-
-        return currentlyDefault
+        return currentDefaultBrowser.lowercased() == selfBundleID.lowercased()
     }
-    
-    // set DefaultBrowser as the OS level link handler
-    func setAsDefault() {
-        let selfBundleID = Bundle.main.bundleIdentifier! as CFString
-        let selfURL = Bundle.main.bundleURL
-        for scheme in supportedSchemes {
-            if #available(macOS 12.0, *) {
-                workspace.setDefaultApplication(at: selfURL, toOpenURLsWithScheme: scheme)
-            } else {
-                LSSetDefaultHandlerForURLScheme(scheme as CFString, selfBundleID)
-            }
+
+    // check if DefaultBrowser is the OS level html file handler
+    func isCurrentlyDefaultHTMLHandler() -> Bool? {
+        guard let selfBundleID = Bundle.main.bundleIdentifier else {
+            return nil
         }
 
-        updateMenuItems()
+        if #available(macOS 12.0, *) {
+            guard let defaultApplicationUrl = workspace.urlForApplication(toOpen: UTType.html),
+                  let currentDefault = Bundle(url: defaultApplicationUrl)?.bundleIdentifier else {
+                return nil
+            }
+            return currentDefault.lowercased() == selfBundleID.lowercased()
+        } else {
+            guard let testUrl = Bundle.main.url(forResource: "test", withExtension: "html") else {
+                return nil
+            }
+            var err: Unmanaged<CFError>?
+            let applicationUrl = LSCopyDefaultApplicationURLForURL(testUrl as CFURL, .viewer, &err)
+            if let err {
+                print(err)
+                return nil
+            }
+            guard let applicationUrl,
+                  let handlerBundleId = Bundle(url: applicationUrl.takeUnretainedValue() as URL)?.bundleIdentifier else {
+                return nil
+            }
+            return handlerBundleId.lowercased() == selfBundleID.lowercased()
+        }
+    }
+
+    // set DefaultBrowser as the OS level link handler
+    func setAsDefaultHttpHandler() {
+        if #available(macOS 12.0, *) {
+            if let testUrl = URL(string: "http:"),
+               let defaultApplicationUrl = workspace.urlForApplication(toOpen: testUrl),
+               let currentDefaultBrowser = Bundle(url: defaultApplicationUrl)?.bundleIdentifier {
+                defaults.primaryBrowser = currentDefaultBrowser
+            }
+            Task {
+                do {
+                    try await workspace.setDefaultApplication(at: Bundle.main.bundleURL, toOpenURLsWithScheme: "http")
+                } catch {
+                    print("failed to set default http scheme handler: \(error)")
+                    let errorAlert = await NSAlert(error: error)
+                    await errorAlert.runModal()
+                }
+                await MainActor.run {
+                    updateMenuItems()
+                }
+            }
+        } else {
+            let selfBundleID = Bundle.main.bundleIdentifier! as CFString
+            for scheme in browserQualifyingSchemes {
+                let error = LSSetDefaultHandlerForURLScheme(scheme as CFString, selfBundleID)
+                if error != noErr {
+                    print("failed to set handler for scheme \(scheme)")
+                }
+            }
+            updateMenuItems()
+        }
+    }
+
+    func setAsDefaultHTMLHandler() {
+        if #available(macOS 12.0, *) {
+            Task {
+                do {
+                    try await workspace.setDefaultApplication(at: Bundle.main.bundleURL, toOpen: .html)
+                } catch {
+                    print("failed to set default html file handler: \(error)")
+                    // this appears to be intentional by Apple, unfortunately
+                    // https://github.com/Hammerspoon/hammerspoon/issues/2205#issuecomment-541972453
+                }
+            }
+        } else {
+            let selfBundleID = Bundle.main.bundleIdentifier! as CFString
+            let error = LSSetDefaultRoleHandlerForContentType("public.html" as CFString, .viewer, selfBundleID)
+            if error != noErr {
+                print("failed to set html file handler")
+            }
+        }
     }
 
     // set to open automatically at login
@@ -551,7 +607,7 @@ class AppDelegate: NSObject {
             menu.insertItem(item, at: idx)
         }
         if let button = statusItem.button {
-            if !isCurrentlyDefault() {
+            if isCurrentlyDefaultHttpHandler() != true {
                 button.image = NSImage(named: "StatusBarButtonImageError")
                 setDefaultButton.isEnabled = true
             } else {
@@ -694,7 +750,7 @@ class AppDelegate: NSObject {
     }
 
     @IBAction func setAsDefaultPress(sender: AnyObject) {
-        setAsDefault()
+        setAsDefaultHttpHandler()
     }
 
 	func doDisclosure(sender: NSButton) {
@@ -761,7 +817,7 @@ extension AppDelegate: NSApplicationDelegate {
 
         defaults.register(defaults: defaultSettings)
 
-        if !isCurrentlyDefault() {
+        if isCurrentlyDefaultHttpHandler() == false {
             let notDefaultAlert = NSAlert()
             notDefaultAlert.addButton(withTitle: "Set As Default")
             notDefaultAlert.addButton(withTitle: "Cancel")
@@ -770,7 +826,7 @@ extension AppDelegate: NSApplicationDelegate {
             notDefaultAlert.alertStyle = .warning
             switch notDefaultAlert.runModal() {
             case NSApplication.ModalResponse.alertFirstButtonReturn:
-                setAsDefault()
+                setAsDefaultHttpHandler()
             default:
                 break
             }

--- a/DefaultBrowser/Base.lproj/MainMenu.xib
+++ b/DefaultBrowser/Base.lproj/MainMenu.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/DefaultBrowser/Defaults.swift
+++ b/DefaultBrowser/Defaults.swift
@@ -63,7 +63,11 @@ class ThisDefaults: UserDefaults {
     // The user's primary browser (their old default browser)
     var primaryBrowser: String? {
         get {
-            return string(forKey: DefaultKey.PrimaryBrowser.rawValue)
+            let value = string(forKey: DefaultKey.PrimaryBrowser.rawValue)
+            if value == "" {
+                return nil
+            }
+            return value
         }
         set (value) {
             // don't set to self

--- a/DefaultBrowser/Info.plist
+++ b/DefaultBrowser/Info.plist
@@ -89,7 +89,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2022 Cameron Little. All rights reserved.</string>
+	<string>Copyright © 2015-2025 Cameron Little. All rights reserved.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/DefaultBrowser/Info.plist
+++ b/DefaultBrowser/Info.plist
@@ -74,7 +74,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>291</string>
+	<string>292</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>SetCurrentBrowserIntent</string>

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ https://defaultbrowser.app
 - **Blocklist** Prevent browsers from automatically opening.
 - **Legacy behavior** Select your primary browser to simulate traditional behavior.
 - **Shortcuts support** Force a specific browser with Siri Shortcuts
+
+## Notes
+
+- No longer can automatically register as `html` file handler. At some point in the past, Apple restricted the ability of apps to register as the default opener for the UTType `public.html` (https://github.com/Hammerspoon/hammerspoon/issues/2205#issuecomment-541972453). Please [do this manually](https://support.apple.com/guide/mac-help/choose-an-app-to-open-a-file-on-mac-mh35597/mac) now


### PR DESCRIPTION
Upgrades from legacy `LS` prefixed apis where possible, with fallbacks.

I ran into some broken behavior when I updated the build number. Turns out, Apple's changed some stuff I didn't know about since I had a working installation. Apps only need to register for `http`, and `https` is sort of automatic. Also, apps can no longer set themselves as default handlers for `.html` files, even using legacy APIs.