### PR TITLE
Replace selection-driven browser blocklist with checkboxes

### DIFF
--- a/DefaultBrowser/AppDelegate.swift
+++ b/DefaultBrowser/AppDelegate.swift
@@ -1195,6 +1195,11 @@ extension BlocklistDelegate: NSTableViewDelegate {
         } else {
             cell = NSTableCellView()
             cell.identifier = col.identifier
+            // A view built from scratch (rather than an IB-authored cell template) has no
+            // autoresizing mask by default, so it never tracks the row's width as the column
+            // resizes — it just keeps whatever frame it had when first created. widthSizable
+            // makes it stretch with the row the same way an IB-authored cell would.
+            cell.autoresizingMask = [.width, .height]
 
             let imageView = NSImageView()
             imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -1203,6 +1208,10 @@ extension BlocklistDelegate: NSTableViewDelegate {
             textField.lineBreakMode = .byTruncatingTail
             let checkboxButton = NSButton(checkboxWithTitle: "", target: nil, action: nil)
             checkboxButton.translatesAutoresizingMaskIntoConstraints = false
+            // Without this, clicking the checkbox makes it (and its row) first responder, which
+            // resets the table's selection to just that row — clobbering a multi-row selection
+            // the user built up specifically to toggle several checkboxes at once.
+            checkboxButton.refusesFirstResponder = true
 
             cell.addSubview(imageView)
             cell.addSubview(textField)

--- a/DefaultBrowser/AppDelegate.swift
+++ b/DefaultBrowser/AppDelegate.swift
@@ -661,18 +661,12 @@ class AppDelegate: NSObject {
 
     // refresh blocklist bar ui
     private func updateBlocklistTable() {
+        // Blocklist membership lives in each row's checkbox now, not in table selection, so this
+        // is just a plain reload (refreshes checkbox state + the primary browser's disabled
+        // appearance) — no more reselecting rows, which fought the table's own scroll-into-view
+        // behavior on every refresh (e.g. a menu update mid-scroll would jump the list).
         blocklistTable.needsDisplay = true
         blocklistTable.reloadData()
-        let blocklist = defaults.browserBlocklist
-        let primaryDefault = defaults.primaryBrowser
-        let selectedRows = NSMutableIndexSet()
-        validBrowsers.enumerated().forEach { (i, browser) in
-            if (blocklist.contains(browser) && primaryDefault != browser) {
-                selectedRows.add(i)
-            }
-        }
-        blocklistTable.deselectAll(self)
-        blocklistTable.selectRowIndexes(selectedRows as IndexSet, byExtendingSelection: false)
     }
 
     private func updateBookmarksTable() {
@@ -1049,6 +1043,10 @@ extension AppDelegate: NSApplicationDelegate {
         blocklistTable.dataSource = blocklistDelegate
         blocklistTable.delegate = blocklistDelegate
         blocklistDelegate.parent = self
+        blocklistTable.usesAlternatingRowBackgroundColors = true
+        if #available(macOS 11.0, *) {
+            blocklistTable.style = .plain // avoid the newer inset/rounded-selection list appearance
+        }
 
         userAccessTable.dataSource = userAccessDelegate
         userAccessTable.delegate = userAccessDelegate
@@ -1066,7 +1064,7 @@ extension AppDelegate: NSApplicationDelegate {
             self.updatePreferencesBrowsersPopup()
 
             // show blocklist contents if it's being used
-            if self.blocklistTable.numberOfSelectedRows > 0 {
+            if !self.defaults.browserBlocklist.isEmpty {
                 self.disclosureTriangle.state = .on
                 self.doDisclosure(sender: self.disclosureTriangle)
             }
@@ -1169,47 +1167,98 @@ class BlocklistDelegate: NSObject {
     weak var parent: AppDelegate?
 }
 
-extension BlocklistDelegate: NSTableViewDataSource { }
-
-extension BlocklistDelegate: NSTableViewDelegate {
+extension BlocklistDelegate: NSTableViewDataSource {
     func numberOfRows(in tableView: NSTableView) -> Int {
         parent?.validBrowsers.count ?? 0
     }
+}
 
+extension BlocklistDelegate: NSTableViewDelegate {
+    // Blocklist membership is a checkbox on each row, independent of table selection. An earlier
+    // version drove membership from table selection itself: selecting a row blocklisted it. That
+    // fought the list's own scroll-into-view behavior on every selection change (the list would
+    // jump to reveal the row whenever anything else refreshed the table, e.g. a menu update), and
+    // made discontiguous ⌘-click selection unpredictable. A checkbox avoids both problems.
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
-        guard let parent, let col = tableColumn else {
+        guard let parent, let col = tableColumn, parent.validBrowsers.indices.contains(row) else {
             return nil
         }
-
         let app = parent.validBrowsers[row]
-        let cell = tableView.makeView(withIdentifier: col.identifier, owner: self) as! NSTableCellView
+        let isPrimary = app == parent.defaults.primaryBrowser
+
+        let cell: NSTableCellView
+        let checkbox: NSButton
+        if let reused = tableView.makeView(withIdentifier: col.identifier, owner: self) as? NSTableCellView,
+           let reusedCheckbox = reused.subviews.first(where: { $0 is NSButton }) as? NSButton {
+            cell = reused
+            checkbox = reusedCheckbox
+        } else {
+            cell = NSTableCellView()
+            cell.identifier = col.identifier
+
+            let imageView = NSImageView()
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            let textField = NSTextField(labelWithString: "")
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            textField.lineBreakMode = .byTruncatingTail
+            let checkboxButton = NSButton(checkboxWithTitle: "", target: nil, action: nil)
+            checkboxButton.translatesAutoresizingMaskIntoConstraints = false
+
+            cell.addSubview(imageView)
+            cell.addSubview(textField)
+            cell.addSubview(checkboxButton)
+            cell.imageView = imageView
+            cell.textField = textField
+
+            NSLayoutConstraint.activate([
+                imageView.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 5),
+                imageView.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                imageView.widthAnchor.constraint(equalToConstant: MENU_ITEM_HEIGHT),
+                imageView.heightAnchor.constraint(equalToConstant: MENU_ITEM_HEIGHT),
+                textField.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 8),
+                textField.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                // Indented by the overlay scrollbar's width in addition to the usual 5pt inset, so
+                // the scroller doesn't cover the checkboxes when it appears.
+                checkboxButton.trailingAnchor.constraint(
+                    equalTo: cell.trailingAnchor,
+                    constant: -(5 + NSScroller.scrollerWidth(for: .regular, scrollerStyle: .overlay))
+                ),
+                checkboxButton.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                textField.trailingAnchor.constraint(lessThanOrEqualTo: checkboxButton.leadingAnchor, constant: -8),
+            ])
+            checkbox = checkboxButton
+        }
+
         if let url = parent.workspace.urlForApplication(withBundleIdentifier: app) {
             let image = parent.workspace.icon(forFile: url.relativePath)
             image.size = NSSize(width: MENU_ITEM_HEIGHT, height: MENU_ITEM_HEIGHT)
             cell.imageView?.image = image
         }
-        cell.textField?.textColor = app == parent.defaults.primaryBrowser
-        ? .disabledControlTextColor
-        : .controlTextColor
+        cell.textField?.textColor = isPrimary ? .disabledControlTextColor : .controlTextColor
         cell.textField?.stringValue = parent.appName(for: app)
+
+        checkbox.tag = row
+        checkbox.target = self
+        checkbox.action = #selector(checkboxToggled(sender:))
+        checkbox.state = (parent.defaults.browserBlocklist.contains(app) && !isPrimary) ? .on : .off
+        checkbox.isEnabled = !isPrimary
         return cell
     }
 
-    func tableView(_ tableView: NSTableView, selectionIndexesForProposedSelection proposedSelectionIndexes: IndexSet) -> IndexSet {
-        guard let parent else {
-            return proposedSelectionIndexes
+    @objc func checkboxToggled(sender: NSButton) {
+        guard let parent, parent.validBrowsers.indices.contains(sender.tag) else {
+            return
         }
-
-        parent.defaults.browserBlocklist = proposedSelectionIndexes
-            .map { parent.validBrowsers[$0] }
-            .filter { $0 != parent.defaults.primaryBrowser }
-        if let primaryBrowser = parent.defaults.primaryBrowser,
-           let primaryIndex = parent.validBrowsers.firstIndex(of: primaryBrowser) {
-            let newSelection = NSMutableIndexSet(indexSet: proposedSelectionIndexes)
-            newSelection.remove(primaryIndex)
-            return newSelection as IndexSet
+        let app = parent.validBrowsers[sender.tag]
+        var blocklist = parent.defaults.browserBlocklist
+        if sender.state == .on {
+            if !blocklist.contains(app) {
+                blocklist.append(app)
+            }
+        } else {
+            blocklist.removeAll { $0 == app }
         }
-        return proposedSelectionIndexes
+        parent.defaults.browserBlocklist = blocklist
     }
 }
 

--- a/DefaultBrowser/AppDelegate.swift
+++ b/DefaultBrowser/AppDelegate.swift
@@ -1249,16 +1249,33 @@ extension BlocklistDelegate: NSTableViewDelegate {
         guard let parent, parent.validBrowsers.indices.contains(sender.tag) else {
             return
         }
-        let app = parent.validBrowsers[sender.tag]
+        // If the toggled row is part of a multi-row selection, apply the same resulting state to
+        // every selected row instead of just the one that was clicked — matches the explanatory
+        // label ("check or uncheck multiple items by selecting more than one"), since a plain
+        // NSButton in a view-based table row has no built-in multi-row checkbox propagation the
+        // way a cell-based checkbox column does.
+        let table = parent.blocklistTable!
+        var rows: IndexSet = [sender.tag]
+        if table.selectedRowIndexes.contains(sender.tag) {
+            rows = table.selectedRowIndexes
+        }
+
+        let newState = sender.state == .on
         var blocklist = parent.defaults.browserBlocklist
-        if sender.state == .on {
-            if !blocklist.contains(app) {
-                blocklist.append(app)
+        for row in rows {
+            guard parent.validBrowsers.indices.contains(row) else { continue }
+            let app = parent.validBrowsers[row]
+            guard app != parent.defaults.primaryBrowser else { continue }
+            if newState {
+                if !blocklist.contains(app) {
+                    blocklist.append(app)
+                }
+            } else {
+                blocklist.removeAll { $0 == app }
             }
-        } else {
-            blocklist.removeAll { $0 == app }
         }
         parent.defaults.browserBlocklist = blocklist
+        table.reloadData() // refresh every affected row's checkbox, not just the clicked one
     }
 }
 

--- a/DefaultBrowser/AppDelegate.swift
+++ b/DefaultBrowser/AppDelegate.swift
@@ -665,8 +665,14 @@ class AppDelegate: NSObject {
         // is just a plain reload (refreshes checkbox state + the primary browser's disabled
         // appearance) — no more reselecting rows, which fought the table's own scroll-into-view
         // behavior on every refresh (e.g. a menu update mid-scroll would jump the list).
+        // reloadData() clears the table's selection as a side effect, so capture/restore it —
+        // this runs (via the browserBlocklist KVO observer) every time a checkbox is toggled,
+        // and losing the selection there would clobber a multi-row selection built up
+        // specifically to toggle several checkboxes together.
+        let selection = blocklistTable.selectedRowIndexes
         blocklistTable.needsDisplay = true
         blocklistTable.reloadData()
+        blocklistTable.selectRowIndexes(selection, byExtendingSelection: false)
     }
 
     private func updateBookmarksTable() {
@@ -1047,6 +1053,7 @@ extension AppDelegate: NSApplicationDelegate {
         if #available(macOS 11.0, *) {
             blocklistTable.style = .plain // avoid the newer inset/rounded-selection list appearance
         }
+        NotificationCenter.default.addObserver(blocklistDelegate, selector: #selector(BlocklistDelegate.windowResized(_:)), name: NSWindow.didResizeNotification, object: preferencesWindow)
 
         userAccessTable.dataSource = userAccessDelegate
         userAccessTable.delegate = userAccessDelegate
@@ -1174,6 +1181,16 @@ extension BlocklistDelegate: NSTableViewDataSource {
 }
 
 extension BlocklistDelegate: NSTableViewDelegate {
+    // The primary browser's checkbox is always unchecked and disabled (it can never be
+    // blocklisted), so its row shouldn't be selectable either — otherwise it can end up part of a
+    // multi-row selection whose checkbox-toggle silently skips it, which looks broken.
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        guard let parent, parent.validBrowsers.indices.contains(row) else {
+            return true
+        }
+        return parent.validBrowsers[row] != parent.defaults.primaryBrowser
+    }
+
     // Blocklist membership is a checkbox on each row, independent of table selection. An earlier
     // version drove membership from table selection itself: selecting a row blocklisted it. That
     // fought the list's own scroll-into-view behavior on every selection change (the list would
@@ -1208,10 +1225,6 @@ extension BlocklistDelegate: NSTableViewDelegate {
             textField.lineBreakMode = .byTruncatingTail
             let checkboxButton = NSButton(checkboxWithTitle: "", target: nil, action: nil)
             checkboxButton.translatesAutoresizingMaskIntoConstraints = false
-            // Without this, clicking the checkbox makes it (and its row) first responder, which
-            // resets the table's selection to just that row — clobbering a multi-row selection
-            // the user built up specifically to toggle several checkboxes at once.
-            checkboxButton.refusesFirstResponder = true
 
             cell.addSubview(imageView)
             cell.addSubview(textField)
@@ -1254,6 +1267,16 @@ extension BlocklistDelegate: NSTableViewDelegate {
         return cell
     }
 
+    // The table's single column has resizeWithTable="YES" / columnAutoresizingStyle="lastColumnOnly"
+    // in the XIB, which normally keeps a table's last column in sync with the table's own width —
+    // but that redistribution never actually ran here on window resize, leaving the column pinned
+    // at its initial XIB width and a growing dead zone of table background to the right of the
+    // real content as the window widened. sizeToFit() forces the column to fill the table's
+    // current width.
+    @objc func windowResized(_ note: Notification) {
+        parent?.blocklistTable.sizeToFit()
+    }
+
     @objc func checkboxToggled(sender: NSButton) {
         guard let parent, parent.validBrowsers.indices.contains(sender.tag) else {
             return
@@ -1284,7 +1307,10 @@ extension BlocklistDelegate: NSTableViewDelegate {
             }
         }
         parent.defaults.browserBlocklist = blocklist
-        table.reloadData() // refresh every affected row's checkbox, not just the clicked one
+        // Setting browserBlocklist triggers the KVO observer (resetBrowsers ->
+        // updateBlocklistTable), which reloads the table and preserves selection — no need to
+        // reload here too, and reloading twice was clearing the selection before that observer's
+        // preserve/restore logic ever got a chance to run.
     }
 }
 

--- a/DefaultBrowser/Base.lproj/MainMenu.xib
+++ b/DefaultBrowser/Base.lproj/MainMenu.xib
@@ -219,7 +219,7 @@
                                                         <rect key="frame" x="18" y="160" width="618" height="28"/>
                                                         <textFieldCell key="cell" selectable="YES" id="5VN-Uf-Tp9">
                                                             <font key="font" metaFont="message" size="11"/>
-                                                            <string key="title">Browsers selected in the blocklist will never be opened by Default Browser, even if last used. Hold ⌘ or ⇧ to select multiple or deselect.</string>
+                                                            <string key="title">Checked browsers will never be opened by Default Browser, even if last used. Check or uncheck multiple items by selecting more than one.</string>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>


### PR DESCRIPTION
Blocklist membership was driven by table selection itself (selecting a row blocklisted it), which fought the list's own scroll-into-view behavior on every refresh and made discontiguous ⌘-click selection awkward. Each row now has its own checkbox as the source of truth, decoupled from selection — selecting a range and toggling one checkbox applies to the whole selection, the primary browser's row can't be selected or blocklisted, and the column now actually tracks the table's width on resize (it never did, despite the XIB's resizeWithTable/columnAutoresizingStyle settings).